### PR TITLE
Added 2 levels to Introductions chapter

### DIFF
--- a/lib/courses_data.dart
+++ b/lib/courses_data.dart
@@ -578,13 +578,118 @@ Future<List<List<dynamic>>> getCoursesData({required String firstName}) async {
             ]
           }
         ]
-      },
+      }
+    ],
+    [
       {
         "courseName": "introduction",
         "image": Assets.images.pen.path,
         "color": 0xffCE82FF,
-        "levels": []
-      },
+        "levels": [
+          {
+            "level": 1,
+            "questions": [
+              {
+                "type": "multiple_choice",
+                "prompt": "Choose the correct greeting",
+                "sentence": "How do you say 'Hello' in Kannada?",
+                "options": ["Namaskara", "Dhanyavādagaḷu", "Ninna hesaru ēnu?"],
+                "correctAnswer": "Namaskara"
+              },
+              {
+                "type": "translation",
+                "prompt": "Translate to English",
+                "sentence": "Namaskara",
+                "options": ["Good morning", "Hello", "Thank you"],
+                "correctAnswer": "Hello"
+              },
+              {
+                "type": "fill_in_the_blank",
+                "prompt": "Complete the greeting",
+                "sentence": "______ hēgiddīrā?",
+                "options": ["Nīvu", "Ninna", "Nanna"],
+                "correctAnswer": "Nīvu"
+              },
+              {
+                "type": "multiple_choice",
+                "prompt": "Choose the correct response",
+                "sentence": "What is the correct response to 'Namaskara'?",
+                "options": ["Namaskara", "Nimma hesaru ēnu?", "Hōgibanni"],
+                "correctAnswer": "Namaskara"
+              },
+              {
+                "type": "fill_in_the_blank",
+                "prompt": "Complete the phrase",
+                "sentence": "Nimma hesaru ______?",
+                "options": ["ēnu", "yāru", "hēge"],
+                "correctAnswer": "ēnu"
+              },
+              {
+                "type": "translation",
+                "prompt": "Translate to Kannada",
+                "sentence": "Thank you",
+                "options": ["Namaskara", "Nimma hesaru ēnu?", "Dhanyavādagaḷu"],
+                "correctAnswer": "Dhanyavādagaḷu"
+              },
+              {
+                "type": "multiple_choice",
+                "prompt": "Choose the formal way to ask 'How are you?'",
+                "sentence": "",
+                "options": [
+                  "Nīvu hēgiddīrā?",
+                  "Nīnu hēgiddīyā?",
+                  "Nanna hesaru ēnu?"
+                ],
+                "correctAnswer": "Nīvu hēgiddīrā?"
+              }
+            ]
+          },
+          {
+            "level": 2,
+            "questions": [
+              {
+                "type": "multiple_choice",
+                "prompt": "Identify the informal greeting",
+                "sentence": "",
+                "options": [
+                  "Nīnu hēgiddīyā?",
+                  "Nīvu hēgiddīrā?",
+                  "Dhanyavādagaḷu"
+                ],
+                "correctAnswer": "Nīnu hēgiddīyā?"
+              },
+              {
+                "type": "fill_in_the_blank",
+                "prompt": "Fill in the missing word",
+                "sentence": "______ hesaru ēnu?",
+                "options": ["Nimma", "Nīvu", "Nanna"],
+                "correctAnswer": "Nimma"
+              },
+              {
+                "type": "fill_in_the_blank",
+                "prompt": "Complete the response",
+                "sentence": "Nānu ______ chennāgiddēne",
+                "options": ["bahala", "illa", "hōgu"],
+                "correctAnswer": "bahala"
+              },
+              {
+                "type": "fill_in_the_blank",
+                "prompt": "Complete the question",
+                "sentence": "______ hēgiddīyā?",
+                "options": ["Nīnu", "Nīvu", "Nānu"],
+                "correctAnswer": "Nīnu"
+              },
+              {
+                "type": "multiple_choice",
+                "prompt": "Identify the correct translation",
+                "sentence": "'Svāgata' means:",
+                "options": ["Welcome", "Goodbye", "Please"],
+                "correctAnswer": "Welcome"
+              }
+            ]
+          }
+        ]
+      }
     ],
     [
       {


### PR DESCRIPTION
- Added 2 levels to the Introductions chapter
- Questions were generated by OpenAI - a glimpse of what we OpenAI can do. We can get even more polished questions with better prompts
- Kannada words came with accents on certain letters. I am not sure if that is the right way or not. I have never seen accents being used for Kannada words in the Latin script before. European languages have this though
- Added a new `type` in question - `fill_in_the_blank`. There is no implementation based on the question type but this will come later I think
-  Honorific vs casual - I think we need to have both versions. A typical Kannada speaker would use both on a typical day, right?